### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,349 @@
-# Security Policy
-
-### Reporting a vulnerability
-
-Please do not open GitHub issues or pull requests - this makes the problem immediately visible to everyone, including malicious actors.   
-
-Security issues in this open-source project can be safely reported to Stripe's [Vulnerability Disclosure and Reward Program](https://stripe.com/docs/security/stripe#disclosure-and-reward-program).
-Stripe's security team will triage your report and respond according to its impact on Stripe users and systems.
+6:50:23 PM: build-image version: eaaf26532258c7e103a0d73173f1190b61d98750 (noble)
+6:50:23 PM: buildbot version: 0768c4bcd49b4f313099cd17ac3355c0653a94ea
+6:50:23 PM: Fetching cached dependencies
+6:50:23 PM: Failed to fetch cache, continuing with build
+6:50:23 PM: Starting to prepare the repo for build
+6:50:23 PM: No cached dependencies found. Cloning fresh repo
+6:50:23 PM: git clone --filter=blob:none https://github.com/netlify-templates/content-ops-starter
+6:50:24 PM: Preparing Git Reference refs/heads/main
+6:50:25 PM: Pushing to repository git@github.com:viviarentals/viviarentals.netlify.app
+6:50:31 PM: Starting to install dependencies
+6:50:31 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:31 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:31 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:31 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:31 PM: You can disable idiomatic version files with:
+6:50:31 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:31 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:31 PM: Python version set to 3.13.3
+6:50:31 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:31 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:31 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:31 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:31 PM: You can disable idiomatic version files with:
+6:50:31 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:31 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: Ruby version set to 3.4.3
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: Go version set to 1.24.3
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: Using PHP version 8.3
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:32 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:32 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:32 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:32 PM: You can disable idiomatic version files with:
+6:50:32 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:32 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:33 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:33 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:33 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:33 PM: You can disable idiomatic version files with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:33 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:33 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:33 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:33 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:33 PM: You can disable idiomatic version files with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:33 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:33 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:33 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:33 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:33 PM: You can disable idiomatic version files with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:33 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:33 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:33 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:33 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:33 PM: You can disable idiomatic version files with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:33 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:33 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:33 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:33 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:33 PM: You can disable idiomatic version files with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:33 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:33 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:33 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:33 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:33 PM: You can disable idiomatic version files with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:33 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:33 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:33 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:33 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:33 PM: You can disable idiomatic version files with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:33 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:33 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:33 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:33 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:33 PM: You can disable idiomatic version files with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:33 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:33 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:33 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:33 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:33 PM: You can disable idiomatic version files with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:33 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:33 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:50:33 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:50:33 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:50:33 PM: You can disable idiomatic version files with:
+6:50:33 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:50:33 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:50:33 PM: Attempting Node.js version 'v18' from .nvmrc
+6:50:34 PM: Downloading and installing node v18.20.8...
+6:50:34 PM: Downloading https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.xz...
+6:50:34 PM: Computing checksum with sha256sum
+6:50:34 PM: Checksums matched!
+6:50:38 PM: Now using node v18.20.8 (npm v10.8.2)
+6:50:39 PM: Enabling Node.js Corepack
+6:50:39 PM: Started restoring cached build plugins
+6:50:39 PM: Finished restoring cached build plugins
+6:50:39 PM: Started restoring cached corepack dependencies
+6:50:39 PM: Finished restoring cached corepack dependencies
+6:50:39 PM: No npm workspaces detected
+6:50:39 PM: Started restoring cached node modules
+6:50:39 PM: Finished restoring cached node modules
+6:50:39 PM: Installing npm packages using npm version 10.8.2
+6:50:42 PM: npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+6:50:42 PM: npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+6:50:42 PM: npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+6:50:42 PM: npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+6:50:42 PM: npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+6:50:42 PM: npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
+6:50:42 PM: npm warn deprecated string-similarity@1.2.2: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+6:50:43 PM: npm warn deprecated google-p12-pem@3.1.4: Package is no longer maintained
+6:51:01 PM: added 682 packages in 22s
+6:51:01 PM: npm packages installed
+6:51:02 PM: Successfully installed dependencies
+6:51:02 PM: Starting build script
+6:51:02 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:51:02 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:51:02 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:51:02 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:51:02 PM: You can disable idiomatic version files with:
+6:51:02 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:51:02 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:51:02 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:51:02 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:51:02 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:51:02 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:51:02 PM: You can disable idiomatic version files with:
+6:51:02 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:51:02 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:51:02 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:51:02 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:51:02 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:51:02 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:51:02 PM: You can disable idiomatic version files with:
+6:51:02 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:51:02 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:51:02 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:51:02 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:51:02 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:51:02 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:51:02 PM: You can disable idiomatic version files with:
+6:51:02 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:51:02 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:51:02 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:51:02 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:51:02 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:51:02 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:51:02 PM: You can disable idiomatic version files with:
+6:51:02 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:51:02 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:51:02 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
+6:51:02 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
+6:51:02 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
+6:51:02 PM:     mise settings add idiomatic_version_file_enable_tools node
+6:51:02 PM: You can disable idiomatic version files with:
+6:51:02 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
+6:51:02 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
+6:51:03 PM: Detected 1 framework(s)
+6:51:03 PM: "next" at version "15.3.2"
+6:51:03 PM: Section completed: initializing
+6:51:04 PM: ​
+6:51:04 PM: Netlify Build                                                 
+6:51:04 PM: ────────────────────────────────────────────────────────────────
+6:51:04 PM: ​
+6:51:04 PM: ❯ Version
+6:51:04 PM:   @netlify/build 33.1.3
+6:51:04 PM: ​
+6:51:04 PM: ❯ Flags
+6:51:04 PM:   accountId: 67fbb3d59f81bd17346cd2b5
+6:51:04 PM:   baseRelDir: true
+6:51:04 PM:   buildId: 682e82de66d6c8656fbdcb05
+6:51:04 PM:   deployId: 682e82de66d6c8656fbdcb07
+6:51:04 PM: ​
+6:51:04 PM: ❯ Current directory
+6:51:04 PM:   /opt/build/repo
+6:51:04 PM: ​
+6:51:04 PM: ❯ Config file
+6:51:04 PM:   /opt/build/repo/netlify.toml
+6:51:04 PM: ​
+6:51:04 PM: ❯ Context
+6:51:04 PM:   production
+6:51:05 PM: ​
+6:51:05 PM: ❯ Installing extensions
+6:51:05 PM:    - async-workloads
+6:51:05 PM:    - user-agent-blocker


### PR DESCRIPTION
6:52:41 PM: Deploy site                                                   
6:52:41 PM: ────────────────────────────────────────────────────────────────
6:52:41 PM: ​
6:52:41 PM: Starting to deploy site from '.next'
6:52:41 PM: Calculating files to upload
6:52:41 PM: 0 new file(s) to upload
6:52:41 PM: 1 new function(s) to upload
6:52:49 PM: Section completed: deploying
6:52:51 PM: Finished waiting for live deploy in 2.219s
6:52:51 PM: Site deploy was successfully initiated
6:52:51 PM: ​
6:52:51 PM: (Deploy site completed in 10s)
6:52:53 PM: (node:3349) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 unpipe listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:52:53 PM: (Use `node --trace-warnings ...` to show where the warning was created)
6:52:53 PM: (node:3349) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:52:53 PM: (node:3349) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:52:53 PM: (node:3349) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 finish listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:52:53 PM: (node:3349) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 unpipe listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:52:53 PM: (node:3349) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:52:53 PM: (node:3349) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
6:52:53 PM: (node:3349) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 finish listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
Cleanup
In progress
6:52:54 PM: Netlify Build Complete                                        
6:52:54 PM: ────────────────────────────────────────────────────────────────
6:52:54 PM: ​
6:52:55 PM: Caching artifacts
6:52:55 PM: Started saving node modules
6:52:55 PM: Finished saving node modules
6:52:55 PM: Started saving build plugins
6:52:55 PM: Finished saving build plugins
6:52:55 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:52:55 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:52:55 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:52:55 PM:     mise settings add idiomatic_version_file_enable_tools node
6:52:55 PM: You can disable idiomatic version files with:
6:52:55 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:52:55 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:52:55 PM: Started saving go cache
6:52:58 PM: Finished saving go cache
6:52:58 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:52:58 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:52:58 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:52:58 PM:     mise settings add idiomatic_version_file_enable_tools node
6:52:58 PM: You can disable idiomatic version files with:
6:52:58 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:52:58 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:52:58 PM: Started saving python cache
6:53:07 PM: Finished saving python cache
6:53:07 PM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
6:53:07 PM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
6:53:07 PM: You can remove this warning by explicitly enabling idiomatic version files for node with:
6:53:07 PM:     mise settings add idiomatic_version_file_enable_tools node
6:53:07 PM: You can disable idiomatic version files with:
6:53:07 PM:     mise settings add idiomatic_version_file_enable_tools "[]"
6:53:07 PM: See https://github.com/jdx/mise/discussions/4345 for more information.
6:53:07 PM: Started saving ruby cache
6:53:22 PM: Finished saving ruby cache
6:53:22 PM: Started saving corepack cache
6:53:22 PM: Finished saving corepack cache
6:53:22 PM: Started saving emacs cask dependencies
6:53:22 PM: Finished saving emacs cask dependencies
6:53:22 PM: Started saving maven dependencies
6:53:22 PM: Finished saving maven dependencies
6:53:22 PM: Started saving boot dependencies
6:53:22 PM: Finished saving boot dependencies
6:53:22 PM: Started saving rust rustup cache
6:53:22 PM: Finished saving rust rustup cache
6:53:23 PM: Build script success
6:54:04 PM: Uploading Cache of size 433.8MB
6:54:05 PM: Section completed: cleanup